### PR TITLE
feat: 트랙 API, 기록 조회 API 및 S3/인증/QueryDSL 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,16 +28,22 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
+
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    // AWS
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,5 +45,12 @@ dependencies {
 
     // AWS
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation "com.querydsl:querydsl-collections:5.0.0"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 

--- a/src/main/java/com/github/sanhak/global/config/QueryDslConfig.java
+++ b/src/main/java/com/github/sanhak/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.github.sanhak.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/github/sanhak/global/external/s3/S3Service.java
+++ b/src/main/java/com/github/sanhak/global/external/s3/S3Service.java
@@ -1,0 +1,40 @@
+package com.github.sanhak.global.external.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Service
+public class S3Service {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // TODO: 추후 CDN 필요시 전환 고려
+    //    @Value("${cloud.aws.s3.cdn-domain:}")
+    //    private String cdnDomain;
+    public String publicUrl(String key) {
+        if (key == null) throw new IllegalArgumentException("S3 key must not be null");
+        // 백슬래시는 슬래시로 정규화
+        key = key.replace("\\", "/");
+
+        // 선행 '/' 제거
+        while (key.startsWith("/")) {
+            key = key.substring(1);
+        }
+
+        // 세그먼트별 인코딩 (RFC 3986 방식)
+        String safeKey = Arrays.stream(key.split("/", -1))
+                .map(seg -> UriUtils.encodePathSegment(seg, StandardCharsets.UTF_8))
+                .collect(Collectors.joining("/"));
+
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + safeKey;
+    }
+}

--- a/src/main/java/com/github/sanhak/global/security/UserAuthInfo.java
+++ b/src/main/java/com/github/sanhak/global/security/UserAuthInfo.java
@@ -1,0 +1,75 @@
+package com.github.sanhak.global.security;
+
+import com.github.sanhak.user.repository.UserEntity;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@AllArgsConstructor
+public class UserAuthInfo implements UserDetails, OAuth2User {
+
+    private final UserEntity user;
+    private final String phoneNumber;
+    private final String password;
+    private final Map<String, Object> attributes;
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    public String getUserPhoneNumber() {
+        return user.getPhoneNumber();
+    }
+
+    @Override
+    public String getUsername() {
+        return phoneNumber != null ? phoneNumber : user.getPhoneNumber();
+    }
+
+    @Override
+    public String getPassword() {
+        return password == null ? "" : password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // --- OAuth2User 구현 ---
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes == null ? Collections.emptyMap() : attributes;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/com/github/sanhak/instrument/repository/InstrumentEntity.java
+++ b/src/main/java/com/github/sanhak/instrument/repository/InstrumentEntity.java
@@ -23,8 +23,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InstrumentEntity extends BaseTimeEntity {
     @Id
+    @Column(name = "instrument_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long instrumentId;
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)

--- a/src/main/java/com/github/sanhak/judgment/repository/JudgmentRepository.java
+++ b/src/main/java/com/github/sanhak/judgment/repository/JudgmentRepository.java
@@ -1,7 +1,0 @@
-package com.github.sanhak.judgment.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface JudgmentRepository extends JpaRepository<JudgmentEntity, Long> {
-
-}

--- a/src/main/java/com/github/sanhak/note/exception/NoteException.java
+++ b/src/main/java/com/github/sanhak/note/exception/NoteException.java
@@ -1,0 +1,11 @@
+package com.github.sanhak.note.exception;
+
+import com.github.sanhak.global.exception.CustomException;
+
+public class NoteException extends CustomException {
+
+    public NoteException(NoteExceptionCode code) {
+
+        super(code);
+    }
+}

--- a/src/main/java/com/github/sanhak/note/exception/NoteExceptionCode.java
+++ b/src/main/java/com/github/sanhak/note/exception/NoteExceptionCode.java
@@ -1,0 +1,17 @@
+package com.github.sanhak.note.exception;
+
+import com.github.sanhak.global.exception.CustomExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoteExceptionCode implements CustomExceptionCode {
+    MEASURE_OR_NOTE_EMPTY("악보에 마디 또는 노트 정보가 없습니다.", 4001),
+    NOTE_INDEX_OUT_OF_RANGE("노트 위치가 허용된 범위를 벗어났습니다. (마디 또는 슬롯 값 확인)", 4002),
+    LYRICS_INDEX_OUT_OF_RANGE("가사 위치가 허용된 범위를 벗어났습니다. (마디 또는 슬롯 값 확인)", 4003),
+    ;
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/com/github/sanhak/note/repository/NoteEntity.java
+++ b/src/main/java/com/github/sanhak/note/repository/NoteEntity.java
@@ -27,17 +27,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoteEntity extends BaseTimeEntity {
     @Id
+    @Column(name = "note_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long noteId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sheet_id",  nullable = false)
     private SheetEntity sheet;
 
-    @Column(nullable = false)
-    private Double timing;
+    @Column(name = "measure_idx", nullable = false)
+    private Integer measureIdx;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "strength",  nullable = false)
-    private NoteStrength strength;
+    @Column(name = "slot_idx", nullable = false)
+    private Integer slotIdx;
+
+    @Column(name = "stroke", nullable = false)
+    private String stroke;
+
+    @Column(name = "lyric")
+    private String lyric;
+
+//    TODO: 연주의 세기(strength) 처리 로직 필요 시 활성화 및 구현
+//    @Enumerated(EnumType.STRING)
+//    @Column(name = "strength",  nullable = false)
+//    private NoteStrength strength;
 }

--- a/src/main/java/com/github/sanhak/note/repository/NoteRepository.java
+++ b/src/main/java/com/github/sanhak/note/repository/NoteRepository.java
@@ -1,7 +1,17 @@
 package com.github.sanhak.note.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NoteRepository extends JpaRepository<NoteEntity, Long> {
 
+    @Query("""
+              select n from NoteEntity n
+              where n.sheet.id = :sheetId
+              order by n.measureIdx asc, n.slotIdx asc
+            """)
+    List<NoteEntity> findBySheetIdOrderByMeasureIdxAscSlotIdxAsc(@Param("sheetId") Long sheetId);
 }

--- a/src/main/java/com/github/sanhak/playresult/controller/PlayResultApi.java
+++ b/src/main/java/com/github/sanhak/playresult/controller/PlayResultApi.java
@@ -1,0 +1,36 @@
+package com.github.sanhak.playresult.controller;
+
+import com.github.sanhak.global.security.UserAuthInfo;
+import com.github.sanhak.playresult.controller.dto.response.PlayResultFindAllResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+
+@Tag(name = "Play Results", description = "지난 기록(집계) 조회 API")
+public interface PlayResultApi {
+
+    @Operation(
+            summary = "지난 기록 전체 조회",
+            description = "사용자의 지난 연주 기록을 최신순으로 페이징 조회하는 GET API"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "연주 데이터 조회 성공"
+                    )
+            }
+    )
+    ResponseEntity<PlayResultFindAllResponse> getPlayResults(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PageableDefault(size = 10, sort = "playedAt", direction = Sort.Direction.DESC) @ParameterObject Pageable pageable
+    );
+}

--- a/src/main/java/com/github/sanhak/playresult/controller/PlayResultController.java
+++ b/src/main/java/com/github/sanhak/playresult/controller/PlayResultController.java
@@ -1,0 +1,31 @@
+package com.github.sanhak.playresult.controller;
+
+import com.github.sanhak.global.security.UserAuthInfo;
+import com.github.sanhak.playresult.controller.dto.response.PlayResultFindAllResponse;
+import com.github.sanhak.playresult.service.PlayResultService;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/me/play-results")
+@RequiredArgsConstructor
+public class PlayResultController implements PlayResultApi {
+    private final PlayResultService playResultService;
+
+    @GetMapping
+    public ResponseEntity<PlayResultFindAllResponse> getPlayResults(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PageableDefault(size = 10, sort = "playedAt", direction = Sort.Direction.DESC) @ParameterObject Pageable pageable
+            )
+        {
+            return ResponseEntity.ok(playResultService.getPlayResults(userAuthInfo.getUserId(), pageable));
+        }
+}

--- a/src/main/java/com/github/sanhak/playresult/controller/dto/response/PlayResultFindAllResponse.java
+++ b/src/main/java/com/github/sanhak/playresult/controller/dto/response/PlayResultFindAllResponse.java
@@ -1,0 +1,58 @@
+package com.github.sanhak.playresult.controller.dto.response;
+
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.playresult.repository.PlayResultEntity;
+import com.github.sanhak.sheet.repository.SheetDifficulty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PlayResultFindAllResponse(
+        @Schema(description = "지난 기록 목록")
+        List<PlayResultSummary> playResults,
+
+        @Schema(description = "전체 페이지 수", example = "5")
+        int totalPages
+) {
+    public record PlayResultSummary(
+            @Schema(description = "기록 ID", example = "1")
+            Long id,
+
+            @Schema(description = "트랙 ID", example = "1")
+            Long trackId,
+
+            @Schema(description = "트랙 제목", example = "별달거리")
+            String trackTitle,
+
+            @Schema(description = "난이도", example = "normal")
+            SheetDifficulty difficulty,
+
+            @Schema(description = "악기", example = "buk")
+            InstrumentType instrument,
+
+            @Schema(description = "정확도(0.0~1.0)", example = "0.875")
+            Double accuracy,
+
+            @Schema(description = "점수", example = "811250")
+            Integer score,
+
+            @Schema(description = "플레이 시각(UTC)", example = "2025-08-23T12:34:56Z")
+            LocalDateTime playedAt
+    ) {
+            public static PlayResultSummary from(PlayResultEntity result) {
+                    return new PlayResultSummary(
+                            result.getId(),
+                            result.getSheet().getTrack().getId(),
+                            result.getSheet().getTrack().getTitle(),
+                            result.getSheet().getDifficulty(),
+                            result.getSheet().getInstrument().getType(),
+                            result.getAccuracy(),
+                            result.getScore(),
+                            result.getPlayedAt()
+                    );
+            }
+    }
+}

--- a/src/main/java/com/github/sanhak/playresult/exception/PlayResultException.java
+++ b/src/main/java/com/github/sanhak/playresult/exception/PlayResultException.java
@@ -1,0 +1,11 @@
+package com.github.sanhak.playresult.exception;
+
+import com.github.sanhak.global.exception.CustomException;
+
+public class PlayResultException extends CustomException {
+
+    public PlayResultException(PlayResultExceptionCode code) {
+
+        super(code);
+    }
+}

--- a/src/main/java/com/github/sanhak/playresult/exception/PlayResultExceptionCode.java
+++ b/src/main/java/com/github/sanhak/playresult/exception/PlayResultExceptionCode.java
@@ -1,0 +1,18 @@
+package com.github.sanhak.playresult.exception;
+
+import com.github.sanhak.global.exception.CustomExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlayResultExceptionCode implements CustomExceptionCode {
+    INVALID_TOTAL("전체 노트 수(total)는 성공 노트 수(success)와 실패 노트 수(fail)의 합과 같아야 합니다.", 5001),
+    INVALID_MAX_COMBO("최대 콤보(maxCombo)는 성공 노트 수(success)보다 클 수 없습니다.", 5002),
+    ZERO_TOTAL("전체 노트 수(total)는 0일 수 없습니다. 최소 1 이상의 값이어야 합니다.", 5003),
+    INVALID_FIRST_FAILED_MEASURE("첫 번째로 틀린 마디 번호가 올바르지 않습니다.", 5004),
+    INVALID_FIRST_FAILED_SLOT("첫 번째로 틀린 슬롯 번호가 올바르지 않습니다.", 5005);
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/com/github/sanhak/playresult/repository/PlayResultEntity.java
+++ b/src/main/java/com/github/sanhak/playresult/repository/PlayResultEntity.java
@@ -1,5 +1,6 @@
-package com.github.sanhak.judgment.repository;
+package com.github.sanhak.playresult.repository;
 
+import com.github.sanhak.global.entity.BaseTimeEntity;
 import com.github.sanhak.note.repository.NoteEntity;
 import com.github.sanhak.sheet.repository.SheetEntity;
 import com.github.sanhak.user.repository.UserEntity;
@@ -18,16 +19,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
-@Table(name = "judgments")
+@Table(name = "playresults")
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class JudgmentEntity {
+public class PlayResultEntity extends BaseTimeEntity {
     @Id
+    @Column(name = "play_result_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long judgmentId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -37,14 +41,29 @@ public class JudgmentEntity {
     @JoinColumn(name = "sheet_id", nullable = false)
     private SheetEntity sheet;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "note_id",  nullable = false)
-    private NoteEntity note;
+    @Column(nullable = false)
+    private Integer success;
 
     @Column(nullable = false)
-    private Long success;
+    private Integer fail;
 
-    @Column(nullable = false)
-    private Long fail;
+    @Column(name = "first_failed_measure_idx")
+    private Integer firstFailedMeasureIdx;
+
+    @Column(name = "first_failed_slot_idx")
+    private Integer firstFailedSlotIdx;
+
+    @Column(name = "max_combo", nullable = false)
+    private Integer maxCombo;
+
+    @Column(name = "accuracy", nullable = false)
+    private Double accuracy; // 0.0 ~ 1.0
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    @Column(name = "played_at", nullable = false)
+    private LocalDateTime playedAt;
+
 
 }

--- a/src/main/java/com/github/sanhak/playresult/repository/PlayResultRepository.java
+++ b/src/main/java/com/github/sanhak/playresult/repository/PlayResultRepository.java
@@ -1,0 +1,9 @@
+package com.github.sanhak.playresult.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayResultRepository extends JpaRepository<PlayResultEntity, Long> {
+    Page<PlayResultEntity> findByUserIdOrderByPlayedAtDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/github/sanhak/playresult/service/PlayResultService.java
+++ b/src/main/java/com/github/sanhak/playresult/service/PlayResultService.java
@@ -1,0 +1,29 @@
+package com.github.sanhak.playresult.service;
+
+import com.github.sanhak.playresult.controller.dto.response.PlayResultFindAllResponse.PlayResultSummary;
+import com.github.sanhak.playresult.controller.dto.response.PlayResultFindAllResponse;
+import com.github.sanhak.playresult.repository.PlayResultEntity;
+import com.github.sanhak.playresult.repository.PlayResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlayResultService {
+
+    private final PlayResultRepository playResultRepository;
+
+    public PlayResultFindAllResponse getPlayResults(Long userId, Pageable pageable) {
+        Page<PlayResultEntity> result = playResultRepository
+                .findByUserIdOrderByPlayedAtDesc(userId, pageable);
+
+        List<PlayResultSummary> items = result.getContent().stream()
+                .map(PlayResultSummary::from)
+                .toList();
+
+        return new PlayResultFindAllResponse(items, result.getTotalPages());
+    }
+}

--- a/src/main/java/com/github/sanhak/sheet/exception/SheetException.java
+++ b/src/main/java/com/github/sanhak/sheet/exception/SheetException.java
@@ -1,0 +1,11 @@
+package com.github.sanhak.sheet.exception;
+
+import com.github.sanhak.global.exception.CustomException;
+
+public class SheetException extends CustomException {
+
+    public SheetException(SheetExceptionCode code) {
+
+        super(code);
+    }
+}

--- a/src/main/java/com/github/sanhak/sheet/exception/SheetExceptionCode.java
+++ b/src/main/java/com/github/sanhak/sheet/exception/SheetExceptionCode.java
@@ -1,0 +1,16 @@
+package com.github.sanhak.sheet.exception;
+
+import com.github.sanhak.global.exception.CustomExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SheetExceptionCode implements CustomExceptionCode {
+
+    SHEET_NOT_FOUND("악보를 찾을 수 없습니다.", 3001),
+    ;
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/com/github/sanhak/sheet/repository/SheetEntity.java
+++ b/src/main/java/com/github/sanhak/sheet/repository/SheetEntity.java
@@ -27,8 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SheetEntity {
     @Id
+    @Column(name = "sheet_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long sheetId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "instrument_id", nullable = false)
@@ -41,4 +42,10 @@ public class SheetEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "difficulty", nullable = false)
     private SheetDifficulty difficulty;
+
+    @Column(name = "total_measures", nullable = false)
+    private Integer totalMeasures;
+
+    @Column(name = "interval_ms", nullable = false)
+    private Integer intervalMs;
 }

--- a/src/main/java/com/github/sanhak/sheet/repository/SheetRepository.java
+++ b/src/main/java/com/github/sanhak/sheet/repository/SheetRepository.java
@@ -1,7 +1,20 @@
 package com.github.sanhak.sheet.repository;
 
+import com.github.sanhak.instrument.repository.InstrumentType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface SheetRepository extends JpaRepository<SheetEntity, Long> {
-
+    @Query("""
+       select s from SheetEntity s
+       join fetch s.track t
+       where t.id = :trackId and s.instrument = :instrument
+    """)
+    Optional<SheetEntity> findByTrackIdAndInstrument(
+            @Param("trackId") Long trackId,
+            @Param("instrument") InstrumentType instrument
+    );
 }

--- a/src/main/java/com/github/sanhak/track/controller/TrackApi.java
+++ b/src/main/java/com/github/sanhak/track/controller/TrackApi.java
@@ -1,0 +1,69 @@
+package com.github.sanhak.track.controller;
+
+import com.github.sanhak.global.security.UserAuthInfo;
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.track.controller.dto.request.PlayResultRequest;
+import com.github.sanhak.track.controller.dto.response.PlayResultResponse;
+import com.github.sanhak.track.controller.dto.response.TrackListResponse;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Tracks", description = "노래 목록/연주 데이터/연주 완료 API")
+
+public interface TrackApi {
+    @Operation(
+            summary = "노래 목록 조회",
+            description = "선택한 악기(instrument) 기준으로 노래 목록을 반환하는 GET API"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                        responseCode = "200",
+                        description = "전체 노래 목록 조회 성공"
+                    )
+            }
+    )
+    ResponseEntity<TrackListResponse> getAllTracksByInstrument(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            InstrumentType instrument
+    );
+
+    @Operation(
+            summary = "연주 데이터 조회",
+            description = "트랙 ID와 악기에 해당하는 연주 데이터를 반환하는 GET API"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "연주 데이터 조회 성공"
+                    )
+            }
+    )
+    ResponseEntity<TrackSheetGrid> getTrackSheetGridByInstrument(Long trackId, InstrumentType instrument);
+
+    @Operation(
+            summary = "연주 완료 제출",
+            description = "프론트에서 집계한 결과(total, success, fail, maxCombo)를 전송하면 서버가 점수/정확도를 계산해 저장하고 결과를 반환하는 POST API"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "저장 성공"
+                    )
+            }
+    )
+    ResponseEntity<PlayResultResponse> submitPlayResult(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            Long trackId,
+            InstrumentType instrument,
+            @RequestBody PlayResultRequest request
+    );
+}

--- a/src/main/java/com/github/sanhak/track/controller/TrackController.java
+++ b/src/main/java/com/github/sanhak/track/controller/TrackController.java
@@ -1,0 +1,55 @@
+package com.github.sanhak.track.controller;
+
+import com.github.sanhak.global.security.UserAuthInfo;
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.track.controller.dto.request.PlayResultRequest;
+import com.github.sanhak.track.controller.dto.response.PlayResultResponse;
+import com.github.sanhak.track.controller.dto.response.TrackListResponse;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid;
+import com.github.sanhak.track.service.TrackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tracks")
+@RequiredArgsConstructor
+public class TrackController implements TrackApi {
+
+    private final TrackService trackService;
+
+    @GetMapping
+    public ResponseEntity<TrackListResponse> getAllTracksByInstrument(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @RequestParam InstrumentType instrument
+    ) {
+        return ResponseEntity.ok(trackService.getAllTracksByInstrument(userAuthInfo.getUserId(), instrument));
+    }
+
+   @GetMapping("/{trackId}/{instrument}")
+   public ResponseEntity<TrackSheetGrid> getTrackSheetGridByInstrument(
+           @PathVariable Long trackId,
+           @PathVariable InstrumentType instrument
+   ) {
+        return ResponseEntity.ok(trackService.getTrackSheetGridByInstrument(trackId, instrument));
+   }
+
+    @PostMapping("/{trackId}/{instrument}")
+    public ResponseEntity<PlayResultResponse> submitPlayResult(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PathVariable Long trackId,
+            @PathVariable InstrumentType instrument,
+            @Valid @RequestBody PlayResultRequest request
+    ) {
+
+        return ResponseEntity.ok(trackService.submitPlayResult(userAuthInfo.getUserId(), trackId, instrument, request));
+    }
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/request/PlayResultRequest.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/request/PlayResultRequest.java
@@ -1,0 +1,40 @@
+package com.github.sanhak.track.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+
+public record PlayResultRequest(
+
+        @Schema(description = "전체 노트 수", example = "240")
+        @NotNull(message = "전체 노트 수는 필수입니다.")
+        @Min(value = 1, message = "전체 노트 수는 1 이상입니다.")
+        Integer total,
+
+        @Schema(description = "맞춘 노트 수", example = "210")
+        @NotNull(message = "맞춘 노트 수는 필수입니다.")
+        @Min(value = 0, message = "맞춘 노트 수는 0 이상입니다.")
+        Integer success,
+
+        @Schema(description = "틀린 노트 수", example = "30")
+        @NotNull(message = "틀린 노트 수는 필수입니다.")
+        @Min(value = 0, message = "틀린 노트 수는 0 이상입니다.")
+        Integer fail,
+
+        @Schema(description = "최대 콤보(연속 성공 수)", example = "57")
+        @NotNull(message = "최대 콤보 수는 필수입니다.")
+        @Min(value = 0, message = "최대 콤보는 0 이상입니다.")
+        Integer maxCombo,
+
+        @Schema(description = "첫 번째로 틀린 마디 번호(선택, 1부터)", example = "3")
+        @Min(value = 1, message = "마디 번호는 1 이상입니다.")
+        Integer firstFailedMeasureIdx,
+
+        @Schema(description = "첫 번째로 틀린 슬롯 번호(선택, 1~8)", example = "5")
+        @Min(value = 1, message = "슬롯 번호는 1 이상입니다.")
+        @Max(value = 8, message = "슬롯 번호는 8 이하여야 합니다.")
+        Integer firstFailedSlotIdx
+) {
+
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/response/PlayResultResponse.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/response/PlayResultResponse.java
@@ -1,0 +1,30 @@
+package com.github.sanhak.track.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record PlayResultResponse(
+        @Schema(description = "게임 기록 ID", example = "987")
+        Long gameId,
+
+        @Schema(description = "최종 점수", example = "811250")
+        Integer score,
+
+        @Schema(description = "정확도(0.0~1.0)", example = "0.875")
+        Double accuracy,
+
+        @Schema(description = "첫 번째로 틀린 마디 번호(선택, 1부터)", example = "3")
+        Integer firstFailedMeasureIdx,
+
+        @Schema(description = "첫 번째로 틀린 슬롯 번호(선택, 1~8)", example = "5")
+        Integer firstFailedSlotIdx,
+
+        @Schema(description = "최대 콤보 수", example = "57")
+        Integer maxCombo,
+
+        @Schema(description = "플레이 종료 시각", example = "2025-08-23T12:34:56Z")
+        LocalDateTime playedAt
+) {
+
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/response/TrackListResponse.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/response/TrackListResponse.java
@@ -1,0 +1,11 @@
+package com.github.sanhak.track.controller.dto.response;
+
+import java.util.List;
+
+public record TrackListResponse(
+        List<TrackSummary> tracks
+) {
+    public static TrackListResponse from(List<TrackSummary> tracks) {
+        return new TrackListResponse(tracks);
+    }
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/response/TrackRecordSummary.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/response/TrackRecordSummary.java
@@ -1,0 +1,23 @@
+package com.github.sanhak.track.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TrackRecordSummary(
+        @Schema(description = "최근 플레이 일시", example = "2025-08-23T12:34:56Z")
+        LocalDateTime lastPlayedAt,
+
+        @Schema(description = "최근 플레이 정확도", example = "0.75")
+        Double lastAccuracy,
+
+        @Schema(description = "최고 정확도를 달성한 일시", example = "2025-08-20T09:12:00Z")
+        LocalDateTime bestPlayedAt,
+
+        @Schema(description = "최고 정확도", example = "0.9")
+        Double bestAccuracy
+) {
+
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/response/TrackSheetGrid.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/response/TrackSheetGrid.java
@@ -1,0 +1,59 @@
+package com.github.sanhak.track.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.sheet.repository.SheetDifficulty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record TrackSheetGrid(
+        @Schema(description = "트랙 ID", example = "1")
+        Long trackId,
+
+        @Schema(description = "악기", example = "buk")
+        InstrumentType instrument,
+
+        @Schema(description = "시트 ID", example = "123")
+        Long sheetId,
+
+        @Schema(description = "난이도", example = "normal")
+        SheetDifficulty difficulty,
+
+        @Schema(description = "총 마디 수", example = "22")
+        Integer totalMeasures,
+
+        @Schema(description = "슬롯 간 간격(ms)", example = "175")
+        Integer intervalMs,
+
+        @Schema(description = "소요 시간(ms)", example = "30800")
+        Long durationMs,
+
+        @Schema(description = "마디 단위 데이터(연주/가사)")
+        List<Measure> measures,
+
+        @Schema(description = "S3에 업로드된 트랙 오디오 URL")
+        String audioUrl
+) {
+
+    public record Measure(
+            MeasureSlots strokes,
+
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            MeasureSlots lyrics
+    ) {}
+
+    // 한 마디의 8칸 그리드
+    public record MeasureSlots(
+            String first,
+            String second,
+            String third,
+            String fourth,
+            String fifth,
+            String sixth,
+            String seventh,
+            String eighth
+    ) {
+
+    }
+}

--- a/src/main/java/com/github/sanhak/track/controller/dto/response/TrackSummary.java
+++ b/src/main/java/com/github/sanhak/track/controller/dto/response/TrackSummary.java
@@ -1,0 +1,62 @@
+package com.github.sanhak.track.controller.dto.response;
+
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.sheet.repository.SheetDifficulty;
+import com.github.sanhak.track.repository.TrackEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record TrackSummary(
+        @Schema(description = "트랙 ID", example = "1.0") Long trackId,
+
+        @Schema(description = "트랙 제목", example = "별달거리") String title,
+
+        @Schema(description = "악기", example = "장구") InstrumentType instrument,
+
+        @Schema(description = "악기 선택에 따른 트랙 난이도", example = "HARD") SheetDifficulty difficulty,
+
+        @Schema(description = "소요 시간(ms)", example = "38000") Long durationMs,
+
+        @Schema(description = "트랙 오디오 키", example = "uploads/byeoldalgeori.mp3") String audioKey,
+
+        @Schema(description = "S3에 업로드된 트랙 오디오 URL", example = "https://my-bucket.s3.ap-northeast-2.amazonaws" +
+                ".com/uploads/byeoldalgeori.mp3") String audioUrl,
+
+        @Schema(description = "기록 요약") TrackRecordSummary record
+
+) {
+
+    public TrackSummary withAudioUrl(String audioUrl) {
+        return new TrackSummary(
+                this.trackId,
+                this.title,
+                this.instrument,
+                this.difficulty,
+                this.durationMs,
+                this.audioKey,
+                audioUrl,
+                this.record
+        );
+    }
+
+    public static TrackSummary from(
+            TrackEntity trackEntity,
+            InstrumentType instrument,
+            SheetDifficulty difficulty,
+            String audioUrl,
+            TrackRecordSummary record
+    ) {
+
+        return TrackSummary.builder()
+                .trackId(trackEntity.getId())
+                .title(trackEntity.getTitle())
+                .instrument(instrument)
+                .difficulty(difficulty)
+                .durationMs(trackEntity.getDurationMs())
+                .audioKey(trackEntity.getAudioKey())
+                .audioUrl(audioUrl)
+                .record(record)
+                .build();
+    }
+}

--- a/src/main/java/com/github/sanhak/track/exception/TrackException.java
+++ b/src/main/java/com/github/sanhak/track/exception/TrackException.java
@@ -1,0 +1,11 @@
+package com.github.sanhak.track.exception;
+
+import com.github.sanhak.global.exception.CustomException;
+
+public class TrackException extends CustomException {
+
+    public TrackException(TrackExceptionCode code) {
+
+        super(code);
+    }
+}

--- a/src/main/java/com/github/sanhak/track/exception/TrackExceptionCode.java
+++ b/src/main/java/com/github/sanhak/track/exception/TrackExceptionCode.java
@@ -1,0 +1,17 @@
+package com.github.sanhak.track.exception;
+
+import com.github.sanhak.global.exception.CustomExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TrackExceptionCode implements CustomExceptionCode {
+
+    TRACK_NOT_FOUND("트랙을 찾을 수 없습니다.", 2001),
+    TRACK_AUDIO_URL_GENERATION_FAILED("트랙 오디오 URL 생성에 실패했습니다.", 2002),
+    ;
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/com/github/sanhak/track/repository/TrackEntity.java
+++ b/src/main/java/com/github/sanhak/track/repository/TrackEntity.java
@@ -22,12 +22,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrackEntity extends BaseTimeEntity {
     @Id
+    @Column(name = "track_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long trackId;
+    private Long id;
 
     @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)
-    private String audioUrl;
+    private Long durationMs;
+
+    @Column(nullable = false)
+    private String audioKey;
 }

--- a/src/main/java/com/github/sanhak/track/repository/TrackRepository.java
+++ b/src/main/java/com/github/sanhak/track/repository/TrackRepository.java
@@ -2,6 +2,6 @@ package com.github.sanhak.track.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TrackRepository extends JpaRepository<TrackEntity, Long> {
+public interface TrackRepository extends JpaRepository<TrackEntity, Long> , TrackRepositoryCustom{
 
 }

--- a/src/main/java/com/github/sanhak/track/repository/TrackRepositoryCustom.java
+++ b/src/main/java/com/github/sanhak/track/repository/TrackRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.github.sanhak.track.repository;
+
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.track.controller.dto.response.TrackSummary;
+
+import java.util.List;
+
+public interface TrackRepositoryCustom {
+    List<TrackSummary> findAllByInstrument(Long userId, InstrumentType instrument);
+}

--- a/src/main/java/com/github/sanhak/track/repository/TrackRepositoryCustomImpl.java
+++ b/src/main/java/com/github/sanhak/track/repository/TrackRepositoryCustomImpl.java
@@ -1,0 +1,50 @@
+package com.github.sanhak.track.repository;
+
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.instrument.repository.QInstrumentEntity;
+import com.github.sanhak.playresult.repository.QPlayResultEntity;
+import com.github.sanhak.sheet.repository.QSheetEntity;
+import com.github.sanhak.track.controller.dto.response.TrackSummary;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class TrackRepositoryCustomImpl implements TrackRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    QTrackEntity track = QTrackEntity.trackEntity;
+    QSheetEntity sheet = QSheetEntity.sheetEntity;
+    QInstrumentEntity inst = QInstrumentEntity.instrumentEntity;
+    QPlayResultEntity playResult = QPlayResultEntity.playResultEntity;
+
+    @Override
+    public List<TrackSummary> findAllByInstrument(Long userId, InstrumentType instrument) {
+
+        return queryFactory.select(Projections.constructor(
+                TrackSummary.class,
+                track.id,
+                track.title,
+                inst.type,
+                sheet.difficulty,
+                track.durationMs,
+                track.audioKey,
+                ExpressionUtils.as(
+                        JPAExpressions.select(playResult.accuracy.max())
+                                .from(playResult)
+                                .where(playResult.user.id.eq(userId), playResult.sheet.track.id.eq(track.id)), "record"
+                )
+        ))
+        .from(track)
+        .join(sheet).on(sheet.track.eq(track))
+        .join(inst).on(sheet.instrument.eq(inst))
+        .where(inst.type.eq(instrument))
+        .fetch();
+
+    }
+}

--- a/src/main/java/com/github/sanhak/track/service/MeasureGridAssembler.java
+++ b/src/main/java/com/github/sanhak/track/service/MeasureGridAssembler.java
@@ -1,0 +1,117 @@
+package com.github.sanhak.track.service;
+
+import com.github.sanhak.note.exception.NoteException;
+import com.github.sanhak.note.exception.NoteExceptionCode;
+import com.github.sanhak.note.repository.NoteEntity;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid.MeasureSlots;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class MeasureGridAssembler {
+
+    private static final int SLOTS_PER_MEASURE = 8;
+    private static final int SLOT_MIN = 1;
+    private static final int SLOT_MAX = SLOTS_PER_MEASURE;
+
+    // 노트 목록 → (strokes/lyrics) 마디 → measures[{strokes, lyrics}]
+    public List<TrackSheetGrid.Measure> buildFromNotes(int totalMeasures, List<NoteEntity> notes) {
+        log.info("[노트→마디] 시작: 전체 마디 수={}, 노트 개수={}", totalMeasures, (notes == null ? "null" : notes.size()));
+        if (totalMeasures <= 0 || notes == null || notes.isEmpty()) {
+            throw new NoteException(NoteExceptionCode.MEASURE_OR_NOTE_EMPTY);
+        }
+
+        List<MeasureSlots> strokes = buildStrokeGrid(totalMeasures, notes);
+        List<MeasureSlots> lyrics;
+        if (hasAnyLyrics(notes)) {
+            lyrics = buildLyricGrid(totalMeasures, notes);
+        } else {
+            lyrics = null;
+        }
+
+        ArrayList<TrackSheetGrid.Measure> measures = new ArrayList<>(totalMeasures);
+        for (int i = 0; i < totalMeasures; i++) {
+            MeasureSlots s = strokes.get(i);
+            MeasureSlots l = (lyrics != null ? lyrics.get(i) : null);
+            measures.add(new TrackSheetGrid.Measure(s, l));
+        }
+        log.info("[노트→마디] 완료: 생성된 마디 수={}", totalMeasures);
+        return measures;
+    }
+
+    // 연주소리 마디(8칸) 구성
+    private static List<MeasureSlots> buildStrokeGrid(int totalMeasures, List<NoteEntity> notes) {
+
+        List<MeasureSlots> strokeSlotsPerMeasure = createEmptyMeasureGrid(totalMeasures);
+        for (NoteEntity n : notes) {
+            int m = n.getMeasureIdx() - 1;
+            int s = n.getSlotIdx();
+            if (m < 0 || m >= totalMeasures || s < SLOT_MIN || s > SLOT_MAX) {
+                throw new NoteException(NoteExceptionCode.NOTE_INDEX_OUT_OF_RANGE);
+            }
+            strokeSlotsPerMeasure.set(m, applyNoteToSlot(strokeSlotsPerMeasure.get(m), s, defaultIfNull(n.getStroke())));
+        }
+        log.info("[연주소리 마디] 완료: 마디 수={}", totalMeasures);
+        return strokeSlotsPerMeasure;
+    }
+
+    // 가사 마디(8칸) 구성
+    private static List<MeasureSlots> buildLyricGrid(int totalMeasures, List<NoteEntity> notes) {
+
+        List<MeasureSlots> lyricSlotsPerMeasure = createEmptyMeasureGrid(totalMeasures);
+        for (NoteEntity n : notes) {
+            int m = n.getMeasureIdx() - 1;
+            int s = n.getSlotIdx();
+            if (m < 0 || m >= totalMeasures || s < SLOT_MIN || s > SLOT_MAX) {
+                throw new NoteException(NoteExceptionCode.LYRICS_INDEX_OUT_OF_RANGE);
+            }
+            lyricSlotsPerMeasure.set(m, applyNoteToSlot(lyricSlotsPerMeasure.get(m), s, defaultIfNull(n.getLyric())));
+        }
+        log.info("[가사 마디] 완료: 마디 수={}", totalMeasures);
+        return lyricSlotsPerMeasure;
+    }
+
+    // 빈 마디 생성
+    private static List<MeasureSlots> createEmptyMeasureGrid(int total) {
+
+        ArrayList<MeasureSlots> emptyMeasures = new ArrayList<>(Math.max(total, 0));
+        for (int i = 0; i < total; i++) {
+            emptyMeasures.add(new MeasureSlots("", "", "", "", "", "", "", ""));
+        }
+        return emptyMeasures;
+    }
+
+    // 노트 정보를 받아서 마디(8칸)의 특정 슬롯에 값 채워 넣는 함수
+    private static MeasureSlots applyNoteToSlot(MeasureSlots ms, int slot, String value) {
+        String[] slots = new String[] {
+                ms.first(), ms.second(), ms.third(), ms.fourth(),
+                ms.fifth(), ms.sixth(), ms.seventh(), ms.eighth()
+        };
+
+        int idx = slot - 1; // 1~8 -> 0~7
+        if (idx < 0 || idx >= 8) {
+            throw new NoteException(NoteExceptionCode.NOTE_INDEX_OUT_OF_RANGE);
+        }
+
+        slots[idx] = value;
+
+        return new MeasureSlots(
+                slots[0], slots[1], slots[2], slots[3],
+                slots[4], slots[5], slots[6], slots[7]
+        );
+    }
+
+    private static boolean hasAnyLyrics(List<NoteEntity> notes) {
+        for (NoteEntity n : notes) {
+            if (n.getLyric() != null && !n.getLyric().isBlank()) return true;
+        }
+        return false;
+    }
+
+    private static String defaultIfNull(String s) { return (s != null) ? s : ""; }
+}

--- a/src/main/java/com/github/sanhak/track/service/TrackService.java
+++ b/src/main/java/com/github/sanhak/track/service/TrackService.java
@@ -1,0 +1,166 @@
+package com.github.sanhak.track.service;
+
+import com.github.sanhak.global.external.s3.S3Service;
+import com.github.sanhak.note.repository.NoteEntity;
+import com.github.sanhak.playresult.exception.PlayResultException;
+import com.github.sanhak.playresult.exception.PlayResultExceptionCode;
+import com.github.sanhak.playresult.repository.PlayResultEntity;
+import com.github.sanhak.playresult.repository.PlayResultRepository;
+import com.github.sanhak.note.repository.NoteRepository;
+import com.github.sanhak.sheet.exception.SheetException;
+import com.github.sanhak.sheet.exception.SheetExceptionCode;
+import com.github.sanhak.sheet.repository.SheetEntity;
+import com.github.sanhak.sheet.repository.SheetRepository;
+import com.github.sanhak.track.controller.dto.request.PlayResultRequest;
+import com.github.sanhak.track.controller.dto.response.PlayResultResponse;
+import com.github.sanhak.track.controller.dto.response.TrackListResponse;
+
+import com.github.sanhak.instrument.repository.InstrumentType;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid;
+import com.github.sanhak.track.controller.dto.response.TrackSheetGrid.Measure;
+import com.github.sanhak.track.controller.dto.response.TrackSummary;
+import com.github.sanhak.track.exception.TrackException;
+import com.github.sanhak.track.exception.TrackExceptionCode;
+import com.github.sanhak.track.repository.TrackEntity;
+import com.github.sanhak.track.repository.TrackRepository;
+import com.github.sanhak.user.repository.UserEntity;
+import com.github.sanhak.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TrackService {
+
+    private final TrackRepository trackRepository;
+    private final SheetRepository sheetRepository;
+    private final S3Service s3Service;
+    private final NoteRepository noteRepository;
+    private final PlayResultRepository playResultRepository;
+    private final UserService userService;
+    private final MeasureGridAssembler measureGridAssembler;
+
+    public TrackListResponse getAllTracksByInstrument(Long userId, InstrumentType instrument) {
+
+        List<TrackSummary> tracks = trackRepository.findAllByInstrument(userId, instrument);
+
+        if (tracks.isEmpty()) {
+            throw new TrackException(TrackExceptionCode.TRACK_NOT_FOUND);
+        }
+
+        tracks = tracks.stream().map(it -> it.withAudioUrl(generateAudioUrl(it.audioKey()))).toList();
+
+        return TrackListResponse.from(tracks);
+    }
+
+    public TrackSheetGrid getTrackSheetGridByInstrument(Long trackId, InstrumentType instrument) {
+
+        SheetEntity sheet = sheetRepository.findByTrackIdAndInstrument(trackId, instrument)
+                .orElseThrow(() -> new SheetException(SheetExceptionCode.SHEET_NOT_FOUND));
+
+        TrackEntity track = sheet.getTrack();
+
+        List<NoteEntity> notes = noteRepository.findBySheetIdOrderByMeasureIdxAscSlotIdxAsc(sheet.getId());
+
+        List<Measure> measures = measureGridAssembler.buildFromNotes(sheet.getTotalMeasures(), notes);
+
+        String audioUrl = generateAudioUrl(track.getAudioKey());
+
+        return new TrackSheetGrid(
+                track.getId(),
+                instrument,
+                sheet.getId(),
+                sheet.getDifficulty(),
+                sheet.getTotalMeasures(),
+                sheet.getIntervalMs(),
+                track.getDurationMs(),
+                measures,
+                audioUrl
+        );
+    }
+
+    private String generateAudioUrl(String audioKey) {
+
+        if (audioKey == null || audioKey.isBlank()) {
+            return null;
+        }
+        try {
+            return s3Service.publicUrl(audioKey);
+        } catch (Exception e) {
+            throw new TrackException(TrackExceptionCode.TRACK_AUDIO_URL_GENERATION_FAILED);
+        }
+    }
+
+    @Transactional
+    public PlayResultResponse submitPlayResult(
+            Long userId,
+            Long trackId,
+            InstrumentType instrument,
+            @Valid PlayResultRequest request
+    ) {
+
+        UserEntity user = userService.findUserById(userId);
+
+        if (request.total() == 0) {
+            throw new PlayResultException(PlayResultExceptionCode.ZERO_TOTAL);
+        }
+        if (!request.total().equals(request.success() + request.fail())) {
+            throw new PlayResultException(PlayResultExceptionCode.INVALID_TOTAL);
+        }
+        if (request.maxCombo() > request.success()) {
+            throw new PlayResultException(PlayResultExceptionCode.INVALID_MAX_COMBO);
+        }
+
+        SheetEntity sheet = sheetRepository.findByTrackIdAndInstrument(trackId, instrument)
+                .orElseThrow(() -> new TrackException(TrackExceptionCode.TRACK_NOT_FOUND));
+
+        Integer firstMeasure = request.firstFailedMeasureIdx();
+        Integer firstSlot    = request.firstFailedSlotIdx();
+
+        if (firstMeasure != null && firstMeasure < 1) {
+            throw new PlayResultException(PlayResultExceptionCode.INVALID_FIRST_FAILED_MEASURE);
+        }
+        if (firstSlot != null && (firstSlot < 1 || firstSlot > 8)) {
+            throw new PlayResultException(PlayResultExceptionCode.INVALID_FIRST_FAILED_SLOT);
+        }
+
+        // 점수 계산 (정확도 90% + 콤보 10% = 총 1,000,000)
+        double accuracy = request.success().doubleValue() / request.total().doubleValue();
+        int baseScore = (int) Math.round(accuracy * 900_000);
+        int comboScore = (int) Math.round(
+                100_000.0 * (request.maxCombo().doubleValue() / request.total().doubleValue()));
+        int score = baseScore + comboScore;
+
+        LocalDateTime now = LocalDateTime.now();
+        PlayResultEntity result = playResultRepository.save(PlayResultEntity.builder()
+                .user(user)
+                .sheet(sheet)
+                .success(request.success())
+                .fail(request.fail())
+                .firstFailedMeasureIdx(firstMeasure)
+                .firstFailedSlotIdx(firstSlot)
+                .maxCombo(request.maxCombo())
+                .accuracy(accuracy)
+                .score(score)
+                .playedAt(now)
+                .build());
+
+        return new PlayResultResponse(
+                result.getId(),
+                score,
+                accuracy,
+                result.getFirstFailedMeasureIdx(),
+                result.getFirstFailedSlotIdx(),
+                request.maxCombo(),
+                now
+        );
+    }
+}

--- a/src/main/java/com/github/sanhak/user/repository/UserEntity.java
+++ b/src/main/java/com/github/sanhak/user/repository/UserEntity.java
@@ -14,7 +14,7 @@ public class UserEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId;
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/github/sanhak/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/github/sanhak/user/service/UserDetailsServiceImpl.java
@@ -21,9 +21,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String phoneNumer) {
+    public UserDetails loadUserByUsername(String phoneNumber) {
 
-        UserEntity user = userRepository.findByPhoneNumberAndAuthType(phoneNumer, AuthType.PHONE)
+        UserEntity user = userRepository.findByPhoneNumberAndAuthType(phoneNumber, AuthType.PHONE)
                 .orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
         return new User(

--- a/src/main/java/com/github/sanhak/user/service/UserService.java
+++ b/src/main/java/com/github/sanhak/user/service/UserService.java
@@ -1,0 +1,20 @@
+package com.github.sanhak.user.service;
+
+import com.github.sanhak.user.exception.UserException;
+import com.github.sanhak.user.exception.UserExceptionCode;
+import com.github.sanhak.user.repository.UserEntity;
+import com.github.sanhak.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserEntity findUserById(Long userId) {
+
+        return userRepository.findById(userId) .orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,17 +5,24 @@ spring:
     username: ${MYSQL_USERNAME:root}
     password: ${MYSQL_PASSWORD:root}
   jpa:
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-        dialect.storage_engine: innodb
+    open-in-view: false
     show-sql: true
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
   sql:
     init:
       mode: always
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ap-northeast-2
+
 app:
   jwt:
     key: ${JWT_KEY}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- #13 
- #14 
- #15 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- [ ] 지난 플레이 기록 조회 API 구현 (페이징 지원)

- [ ] 	S3 객체 키 기반 퍼블릭 URL 생성 로직 구현
- [ ] TrackEntity에 S3 키 기반 저장 방식 적용 (audioUrl → audioKey, durationMs 추가)
- [ ] 사용자 검증을 위한 UserAuthInfo 구현 (UserDetails, OAuth2User)
- [ ] UserService에 사용자 ID 기반 조회 메서드 추가
- [ ] QueryDSL 설정 추가 (JPAQueryFactory 빈 등록)
- [ ] 트랙 API 구현
      - 노래 목록 조회
      - 연주 데이터 조회
      - 연주 완료
- [ ] 노트를 마디 단위로 변환하는 MeasureGridAssembler 구현

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?